### PR TITLE
fix: disable access to similar channels

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -5947,10 +5947,13 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 forwardedNameLayout[0] = null;
                 forwardedNameLayout[1] = null;
                 drawName = false;
-                if (channelRecommendationsCell == null) {
-                    channelRecommendationsCell = new ChannelRecommendationsCell(this);
-                }
-                channelRecommendationsCell.setMessageObject(messageObject);
+                //CloudVeil start
+                //Block access to Similar Channels.
+                //if (channelRecommendationsCell == null) {
+                //    channelRecommendationsCell = new ChannelRecommendationsCell(this);
+                //}
+                //channelRecommendationsCell.setMessageObject(messageObject);
+                //CloudVeil end
             } else if (messageObject.isExpiredStory()) {
                 if (!messageIdChanged) {
                     requestLayout();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
@@ -5974,11 +5974,14 @@ public class SharedMediaLayout extends FrameLayout implements NotificationCenter
                         scrollSlidingTextTabStrip.addTextTab(TAB_COMMON_GROUPS, getString("SharedGroupsTab2", R.string.SharedGroupsTab2), idToView);
                     }
                 }
-                if (hasRecommendations) {
-                    if (!scrollSlidingTextTabStrip.hasTab(TAB_RECOMMENDED_CHANNELS)) {
-                        scrollSlidingTextTabStrip.addTextTab(TAB_RECOMMENDED_CHANNELS, getString(R.string.SimilarChannelsTab), idToView);
-                    }
-                }
+                //CloudVeil start
+                //Block access to Similar Channels.
+                //if (hasRecommendations) {
+                //    if (!scrollSlidingTextTabStrip.hasTab(TAB_RECOMMENDED_CHANNELS)) {
+                //        scrollSlidingTextTabStrip.addTextTab(TAB_RECOMMENDED_CHANNELS, getString(R.string.SimilarChannelsTab), idToView);
+                //    }
+                //}
+                //CloudVeil end
             }
         }
         int id = scrollSlidingTextTabStrip.getCurrentTabId();


### PR DESCRIPTION
Open CloudVeil Messenger Announcements channel and we will see the Similar Channels feature. 
We need to prevent these from showing in all channels.

- [x] Removed in the chat screen
- [x] Removed in the shared media layout

### Before
<img src='https://github.com/user-attachments/assets/cbc91b15-0819-4a10-90a9-996413c18220' width=300px>


### After
<img src='https://github.com/user-attachments/assets/9aa9a239-a405-4d22-84f1-2bf21bad7716' width=300px>

